### PR TITLE
Tweak instructions for codealong to fix imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,17 @@ that this class inherits from.
 You can see how Python classes inherit from one another by using Python to do some
 _introspection_ on our classes.
 
-Open up the Python shell, and start by importing the files from the `lib` folder:
+First, change directory into the `lib` folder:
+
+```bash
+cd lib
+```
+
+Then, open up the Python shell, and start by importing the files from the `lib` folder:
 
 ```py
-from lib.vehicle import Vehicle
-from lib.car import Car
+from vehicle import Vehicle
+from car import Car
 ```
 
 This will let you interact with the code you've written in those files from


### PR DESCRIPTION
When I ran those lines of code from the python shell i was getting a ModuleNotFoundError:

```python
File "/Users/dakotamartinez/Development/phase3-python/0501-defining-object-inheritance/lib/car.py", line 1, in <module>
    from vehicle import Vehicle
ModuleNotFoundError: No module named 'vehicle'
```
I exited the shell, changed into the lib directory and the imports and was able to get it working as shown.